### PR TITLE
Feature/remove task

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+BasedOnStyle: Mozilla
+AccessModifierOffset: '-4'
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveMacros: 'true'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+BreakBeforeBraces: Allman
+ColumnLimit: '180'
+ConstructorInitializerIndentWidth: '4'
+ContinuationIndentWidth: '4'
+FixNamespaceComments: 'false'
+IndentWidth: '4'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+ReflowComments: 'false'
+SortIncludes: 'false'
+SortUsingDeclarations: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpacesBeforeTrailingComments: '2'
+Standard: Auto
+
+...

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -64,12 +64,12 @@ schedules:
     - master
   always: true
 
-- cron: "0,20,40 * * * *"
+- cron: "0,15,30,45 * * * *"
   displayName: 'CI features'
   branches:
     exclude:
     - master
-  always: false
+  always: true
 
 stages:
 

--- a/include/ssts/task_pool.hpp
+++ b/include/ssts/task_pool.hpp
@@ -82,7 +82,7 @@ public:
         
         _task_cv.notify_all();
 
-        for (auto& t : _threads)
+        for (auto&& t : _threads)
         {
             if (t.joinable())
                 t.join();

--- a/tests/src/test_remove.cpp
+++ b/tests/src/test_remove.cpp
@@ -23,16 +23,29 @@ TEST_F(Remove, RemovedAfterRun)
     EXPECT_EQ(CountScheduledTasks(), 0u);
 }
 
-TEST_F(Remove, RemovedBeforeAfterSleep)
+TEST_F(Remove, RemoveAll)
 {
     n_tasks = 3;
     InitScheduler(4u);
     StartAllTasksIn(1s);
     RemoveAllTasks();
-    EXPECT_EQ(CountScheduledTasks(), n_tasks);
+    EXPECT_EQ(CountScheduledTasks(), 0u);
 
     Sleep(2s);
     EXPECT_EQ(CountScheduledTasks(), 0u);
+}
+
+
+TEST_F(Remove, RestartAllAfterRemoveAll)
+{
+    n_tasks = 3;
+    InitScheduler(4u);
+    StartAllTasksIn(1s);
+    RemoveAllTasks();
+    EXPECT_EQ(CountScheduledTasks(), 0u);
+
+    StartAllTasksIn(1s);
+    EXPECT_EQ(CountScheduledTasks(), n_tasks);
 }
 
 TEST_F(Remove, RemovedLongTiming)


### PR DESCRIPTION
ssts::task_scheduler::remove_task() has been internally redesigned. Temporary "to_be_deleted" task list has been removed and the given task is instantly removed from the pool.